### PR TITLE
Don't use shell=True

### DIFF
--- a/hammercloud/hammercloud.py
+++ b/hammercloud/hammercloud.py
@@ -100,7 +100,7 @@ def main():
         except KeyboardInterrupt:
             return
         if ret:
-            subprocess.call('{0}/{1}.sh'.format(hammercloud.cachedir, ret), shell=True)
+            subprocess.call(['{0}/{1}.sh'.format(hammercloud.cachedir, ret)])
     elif isinstance(servers, list):
         pool = multiprocessing.Pool(len(servers))
         myterm = hcconfig.get('terminal')


### PR DESCRIPTION
Allows us to use this file when connecting to servers with spaces in their names. `ret` is set to the server name, and if there are spaces in it and `shell=True` is used, it will treat each bit as a word. We're not doing any shell stuff in that command line (pipes, `&&`/`||`, etc.), so there's not really a reason to use `shell=True`.
