### PR TITLE
Fix the colors and static importing

### DIFF
--- a/hammercloud/shell/__init__.py
+++ b/hammercloud/shell/__init__.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 
 from hammercloud.shell import expect, pshell  # noqa
+from hammercloud.static import const
 
 
 def spam():

--- a/hammercloud/static/__init__.py
+++ b/hammercloud/static/__init__.py
@@ -1,7 +1,3 @@
 from __future__ import absolute_import
-from hammercloud.static.account import Account
-from hammercloud.static.server import Server
-from hammercloud.static.shell import Shell
-from hammercloud.static import const
 
 __all__ = ['Account', 'Server']


### PR DESCRIPTION
Alright, so python is weird. If something is defined in **init**.py, it
will be run when the module itself is imported. That's fine. However, it
will also run when I import one if it's sub-modules, that is also run. I
have removed the imports from the static **init**.py file, so that we
can safely import `hammercloud.static.const` without running into issues
in the other static things we don't care about.

Fixes #7
